### PR TITLE
Fix 'auth required for publishing' problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The example should explain things.  We accept either token auth or username/pass
 
 ```
 npm install -g npm-copy
-npm-copy --from https://old.npm.mycorp.com --from-token foo --to https://new.npm.mycorp.com --to-username bob --to-password secret mycorp-logger mycorp-stats
+npm-copy --from https://old.npm.mycorp.com --from-token foo --to https://new.npm.mycorp.com --to-username bob --to-password secret --to-email my@corp.com mycorp-logger mycorp-stats
 ```
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   "homepage": "https://github.com/goodeggs/npm-copy",
   "bugs": "https://github.com/goodeggs/npm-copy/issues",
   "dependencies": {
-    "fibers": "^1.0.5",
+    "fibers": "^2.0.0",
     "fibrous": "^0.4.0",
     "lodash": "^3.10.0",
     "minimist": "^1.1.1",
-    "npm-registry-client": "^6.4.0"
+    "npm-registry-client": "^8.5.0"
   },
   "devDependencies": {
     "chai": "^3.0.0",

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -12,6 +12,7 @@ module.exports = fibrous (argv) ->
       token: argv["#{dir}-token"]
       username: argv["#{dir}-username"]
       password: argv["#{dir}-password"]
+      email: argv["#{dir}-email"]
       alwaysAuth: true
 
   moduleNames = argv._


### PR DESCRIPTION
Hello, this tool saved my life... after a few update : [npm-registry-client](https://github.com/npm/npm-registry-client) needs an email in credentials parameters to publish on Nexus.

Thanks for merging