### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "compile": "coffee --bare --compile --output lib/ src/",
     "prepublish": "npm run compile",
     "pretest": "npm run compile",
-    "test": "mocha test/npm_copy.test.coffee"
+    "test": "mocha test/**/*.test.coffee"
   },
   "publishConfig": {
     "registry": "http://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   "dependencies": {
     "fibers": "^4.0.2",
     "fibrous": "^0.4.0",
-    "lodash": "^3.10.0",
+    "lodash": "^4.17.15",
     "minimist": "^1.1.1",
     "npm-registry-client": "^8.5.0"
   },
   "devDependencies": {
     "chai": "^3.0.0",
     "coffee-script": ">=1.8.x",
-    "mocha": "^2.2.5",
+    "mocha": "^7.1.0",
     "mocha-sinon": "^1.1.4",
     "sinon": "^1.15.3"
   },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     "mocha-sinon": "^1.1.4",
     "sinon": "^1.15.3"
   },
+  "mocha": {
+    "require": "coffee-script/register",
+    "reporter": "spec"
+  },
   "scripts": {
     "compile": "coffee --bare --compile --output lib/ src/",
     "prepublish": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "compile": "coffee --bare --compile --output lib/ src/",
     "prepublish": "npm run compile",
     "pretest": "npm run compile",
-    "test": "mocha"
+    "test": "mocha test/npm_copy.test.coffee"
   },
   "publishConfig": {
     "registry": "http://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/goodeggs/npm-copy",
   "bugs": "https://github.com/goodeggs/npm-copy/issues",
   "dependencies": {
-    "fibers": "^2.0.0",
+    "fibers": "^4.0.2",
     "fibrous": "^0.4.0",
     "lodash": "^3.10.0",
     "minimist": "^1.1.1",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,0 @@
---require coffee-script/register
---reporter spec

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,2 @@
---compilers coffee:coffee-script/register
+--require coffee-script/register
 --reporter spec


### PR DESCRIPTION
I failed to `npm install` fibers 2.0.2 on MacOS Catalina, so I decided to try latest stable version of stable in npm-copy. Once that was done, `npm install` was successful, but it still gave security warnings, so I went and updated lodash and mocha. `npm test` reported that new version of mocha doesn't like '--compilers' in mocha.opts, so I had to update it to use `--require`.
After these changes, npm-copy does `npm install` without any issues and `npm test test/npm_copy.test.coffee` reports `1 passing`.